### PR TITLE
Fix timestep embedding concatenation in UNet

### DIFF
--- a/lib/unet.py
+++ b/lib/unet.py
@@ -288,7 +288,7 @@ def timestep_embedding(timesteps, dim, max_period=10000):
     args = timesteps[:, None].astype(jnp.float32) * freqs[None]
     embedding = jnp.concatenate([jnp.cos(args), jnp.sin(args)], axis=-1)
     if dim % 2:
-        embedding = jnp.concatenate.cat([embedding, jnp.zeros_like(embedding[:, :1])], axis=-1)
+        embedding = jnp.concatenate([embedding, jnp.zeros_like(embedding[:, :1])], axis=-1)
     return embedding
 
 class UNetModel(nn.Module):


### PR DESCRIPTION
## Summary
- fix incorrect use of `jnp.concatenate.cat` in `timestep_embedding`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689f4ccb6d3c8327a85930ea44a17fb5