### PR TITLE
Add Upsample2D test without convolution

### DIFF
--- a/lib/test_unet.py
+++ b/lib/test_unet.py
@@ -71,6 +71,13 @@ def test_Upsample2D():
     old_result = old_module(x_torch)
     check(old_result, new_result)
 
+    new_module = unet.Upsample2D(C, use_conv=False)
+    old_module = old_unet.Upsample(C, use_conv=False)
+
+    new_result = new_module(ParamState([]), x)
+    old_result = old_module(x_torch)
+    check(old_result, new_result)
+
 
 @torch.no_grad()
 def test_Downsample2D():


### PR DESCRIPTION
## Summary
- add unit test for Upsample2D when use_conv=False to compare with legacy implementation

## Testing
- `pytest lib/test_unet.py::test_Upsample2D -q` *(fails: module 'jaxlib' has no attribute 'xla_extension')*

------
https://chatgpt.com/codex/tasks/task_e_689f4e2003988327a1a86403ce6a18f8